### PR TITLE
Rocksdb iter using generators + jq filter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,14 @@ $ sudo mv include/* /usr/include/
 
 ### Install RocksDBServer
 
+rocksdbserver uses [jq.py](https://github.com/mwilliamson/jq.py)  which requires the following
+
+```bash
+$ sudo apt-get install autoconf automake build-essential libtool python-dev
+```
+
 ``` bash
-sudo pip install rocksdbserver
+$ sudo pip install rocksdbserver
 ```
 
 ## Usage

--- a/rocksdbserver/rocksdbserver.py
+++ b/rocksdbserver/rocksdbserver.py
@@ -228,7 +228,7 @@ class Table(object):
 
             yield key
 
-    def iter_items(self, seek_to=None, reverse=False, regex=None, jq_filter=None):
+    def iter_items(self, seek_to=None, reverse=False, regex=None, value_filter=None):
         """
         iterates through the items in the database.
         `seek_to` - seeks to the given position if specified.
@@ -236,14 +236,15 @@ class Table(object):
             defaults to the last record if reverse is True.
 
         `regex` - returns only items who's keys match the regex.
-        `jq_filter` - transforms item values (post regex match) using the jq filter.
+        `value_filter` - transforms item values (post regex match) using a jq filter.
+            the jq filter syntax is the same as https://stedolan.github.io/jq/
         """
 
         if regex is not None:
             regex = re.compile(regex)
 
-        if jq_filter is not None:
-            jq_filter = jq(jq_filter)
+        if value_filter is not None:
+            value_filter = jq(value_filter)
 
         _iter = self.rdb.iteritems()
         _iter = self._configure_iterator(_iter, seek_to=seek_to, reverse=reverse)
@@ -254,8 +255,8 @@ class Table(object):
                 continue
 
             value = unpackfn(value)
-            if jq_filter is not None:
-                value = jq_filter.transform(value, multiple_output=True)
+            if value_filter is not None:
+                value = value_filter.transform(value, multiple_output=True)
                 if len(value) == 0:
                     continue
 
@@ -264,7 +265,7 @@ class Table(object):
 
             yield (key, value)
 
-    def iter_values(self, seek_to=None, reverse=False, regex=None, jq_filter=None):
+    def iter_values(self, seek_to=None, reverse=False, regex=None, value_filter=None):
         """
         iterates through the values in the database.
         `seek_to` - seeks to the given position if specified.
@@ -272,11 +273,12 @@ class Table(object):
             defaults to the last record if reverse is True.
 
         `regex` - returns only values who's keys match the regex.
-        `jq_filter` - transforms values (post regex match) using the jq filter.
+        `value_filter` - transforms values (post regex match) using a jq filter.
+            the jq filter syntax is the same as https://stedolan.github.io/jq/
         """
 
         item_iter = self.iter_items(
-            seek_to=seek_to, reverse=reverse, regex=regex, jq_filter=jq_filter,
+            seek_to=seek_to, reverse=reverse, regex=regex, value_filter=value_filter,
         )
         for (key, value) in item_iter:
             yield value
@@ -418,7 +420,7 @@ class RocksDBAPI(object):
             yield key
 
     @ensuretable
-    def iter_values(self, table, seek_to=None, reverse=False, regex=None, jq_filter=None):
+    def iter_values(self, table, seek_to=None, reverse=False, regex=None, value_filter=None):
         '''
         iterates through the values in the table `table`.
         `seek_to` - seeks to the given position if specified.
@@ -426,16 +428,17 @@ class RocksDBAPI(object):
             defaults to the last record if reverse is True.
 
         `regex` - returns only values who's keys match the regex.
-        `jq_filter` - transforms values (post regex match) using the jq filter.
+        `value_filter` - transforms values (post regex match) using a jq filter
+            the jq filter syntax is the same as https://stedolan.github.io/jq/
         '''
         values_iter = table.iter_values(
-            seek_to=seek_to, reverse=reverse, regex=regex, jq_filter=jq_filter,
+            seek_to=seek_to, reverse=reverse, regex=regex, value_filter=value_filter,
         )
         for value in values_iter:
             yield value
 
     @ensuretable
-    def iter_items(self, table, seek_to=None, reverse=False, regex=None, jq_filter=None):
+    def iter_items(self, table, seek_to=None, reverse=False, regex=None, value_filter=None):
         '''
         iterates through the items in the table `table`..
         `seek_to` - seeks to the given position if specified.
@@ -443,10 +446,11 @@ class RocksDBAPI(object):
             defaults to the last record if reverse is True.
 
         `regex` - returns only items who's keys match the regex.
-        `jq_filter` - transforms item values (post regex match) using the jq filter.
+        `value_filter` - transforms item values (post regex match) using a jq filter.
+            the jq filter syntax is the same as https://stedolan.github.io/jq/
         '''
         items_iter = table.iter_items(
-            seek_to=seek_to, reverse=reverse, regex=regex, jq_filter=jq_filter,
+            seek_to=seek_to, reverse=reverse, regex=regex, value_filter=value_filter,
         )
         for (key, value) in items_iter:
             yield (key, value)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'msgpack-python',
         'funcserver',
         'pyrocksdb',
+        'jq',
     ],
     package_dir={'rocksdbserver': 'rocksdbserver'},
     packages=find_packages('.'),


### PR DESCRIPTION
Assuming there's a rocksdb server running on port 8888 with data of the form
```python
['idx11', {'count': 1029, '_id': 'idx11', 'word': 'you', 'id': 'idx11', 'wordlength': 3}]
['idx111', {'count': 99, '_id': 'idx111', 'word': '"And', 'id': 'idx111', 'wordlength': 4}]
['idx1111', {'count': 9, '_id': 'idx1111', 'word': 'fit', 'id': 'idx1111', 'wordlength': 3}]
['idx112', {'count': 96, '_id': 'idx112', 'word': 'how', 'id': 'idx112', 'wordlength': 3}]
['idx11221', {'count': 1, '_id': 'idx11221', 'word': 'lie?', 'id': 'idx11221', 'wordlength': 4}]
['idx11222', {'count': 1, '_id': 'idx11222', 'word': '220', 'id': 'idx11222', 'wordlength': 3}]
['idx121', {'count': 90, '_id': 'idx121', 'word': 'like', 'id': 'idx121', 'wordlength': 4}]
['idx1211', {'count': 9, '_id': 'idx1211', 'word': "It's", 'id': 'idx1211', 'wordlength': 4}]
['idx1212', {'count': 9, '_id': 'idx1212', 'word': 'view', 'id': 'idx1212', 'wordlength': 4}]
```

Here is a sample test script for the functionality
```python
import msgpack
import requests
import json
import time
import sys

url = "http://localhost:8888/rpc"
data = {
    "fn": "iter_items",
    "args": [],
    "kwargs": {
        "table": "MyTable",
        "seek_to": "idx112",
        "regex": "^idx[1]+$",
        "reverse": true,
        "jq_filter": 'select(.wordlength == 3)|{"id": .id, "word": .word}'
    }
}

print "posting to %s, data %s" % (url, data)

serialized_data = msgpack.packb(data)
resp = requests.post(url, data=serialized_data, stream=True)
print "got resp %s" % resp

decoder = msgpack.Unpacker()
while True:
    data = resp.raw.read(1024)
    if not data:
        break

    decoder.feed(data)
    for item in decoder:
        print "got item: %s" % item

    time.sleep(0.1)
```

output
```
got item: ['idx1111', {'word': 'fit', 'id': 'idx1111'}]
got item: ['idx11', {'word': 'you', 'id': 'idx11'}]
```